### PR TITLE
Quick Update on jobBoard.ts regarding recent changes on WaterlooWorks

### DIFF
--- a/src/lib/jobBoard.ts
+++ b/src/lib/jobBoard.ts
@@ -11,15 +11,15 @@ interface JobBoardSpec {
 
 export const JOB_BOARD_SPEC: { [jobBoard in JobBoard]: JobBoardSpec } = {
     [JobBoard.coop]: {
-        name: 'Co-op',
-        url: 'https://waterlooworks.uwaterloo.ca/myAccount/co-op/coop-postings.htm',
+        name: 'Co-op - Full-cycle Service',
+        url: 'https://waterlooworks.uwaterloo.ca/myAccount/co-op/full/jobs.htm',
     },
     [JobBoard.fulltime]: {
         name: 'Full-time',
-        url: 'https://waterlooworks.uwaterloo.ca/myAccount/hire-waterloo/full-time-jobs/jobs-postings.htm',
+        url: 'https://waterlooworks.uwaterloo.ca/myAccount/graduating/jobs.htm',
     },
     [JobBoard.other]: {
         name: 'Other',
-        url: 'https://waterlooworks.uwaterloo.ca/myAccount/hire-waterloo/other-jobs/jobs-postings.htm',
+        url: 'https://waterlooworks.uwaterloo.ca/myAccount/contract/jobs.htm',
     },
 }

--- a/src/lib/jobBoard.ts
+++ b/src/lib/jobBoard.ts
@@ -11,7 +11,7 @@ interface JobBoardSpec {
 
 export const JOB_BOARD_SPEC: { [jobBoard in JobBoard]: JobBoardSpec } = {
     [JobBoard.coop]: {
-        name: 'Co-op - Full-cycle Service',
+        name: 'Co-op Cycle',
         url: 'https://waterlooworks.uwaterloo.ca/myAccount/co-op/full/jobs.htm',
     },
     [JobBoard.fulltime]: {


### PR DESCRIPTION
Still need to look into how the new `Co-op - Employer-Student Direct` Board can be integrated.
Also the `Potential Co-op Opportunity` quick search tool has gone although these positions can still be searched using these key words